### PR TITLE
feat: add error message when primary branch is different from master …

### DIFF
--- a/kluctl/utils/git_utils.py
+++ b/kluctl/utils/git_utils.py
@@ -214,7 +214,12 @@ def clone_project(url, ref, target_dir, git_cache_up_to_date=None):
         args = ["file://%s" % cache_dir, "--single-branch", target_dir]
         if ref is not None:
             args += ["--branch", ref]
-        Git().clone(*args)
+        try:
+            Git().clone(*args)
+        except GitCommandError as e:
+            if e.status == 255:
+                logger.error("It seems that your primary branch is different from master and your ref is not set explicitly. Please set your ref for %s" % url)
+            raise
 
 def get_git_commit(path):
     g = Git(path)


### PR DESCRIPTION
It seems that there are issues with fetch and clone on primary branches other than master. This PR adds an output with a helpful error message to help the user fixing it by setting the ref explicitly. 