### PR TITLE
feat: add more informative error message when deployment.yml is missing

### DIFF
--- a/kluctl/deployment/deployment_project.py
+++ b/kluctl/deployment/deployment_project.py
@@ -75,8 +75,13 @@ class DeploymentProject(object):
         return yaml_load(rendered)
 
     def load_base_conf(self):
-        if not os.path.exists(os.path.join(self.dir, 'deployment.yml')):
-            raise CommandError("deployment.yml not found")
+        base_conf_path = os.path.join(self.dir, 'deployment.yml')
+        if not os.path.exists(base_conf_path):
+            if os.path.exists(os.path.join(self.dir, 'kustomization.yml')):
+                error_text = "deployment.yml not found but folder %s contains kustomization.yml. Is it a kustomizeDir?" % self.dir
+            else:
+                error_text = "%s not found" % base_conf_path
+            raise CommandError(error_text)
 
         self.conf = self.load_rendered_yaml('deployment.yml', self.jinja_vars)
         if self.conf is None:


### PR DESCRIPTION
If a kustomizeDir is mistakenly configured as an include, the error message "deployment.yml not found" is not very helpful. I added two things: 

- If a kustomization.yml was found instead of a deployment.yml, the user gets a helpful error message with a hint to the solution
- In any other case, the complete path to the missing deployment.yml will be printed to help the user find the problematic include